### PR TITLE
Draw Items

### DIFF
--- a/src/main/java/entities/items/Item.java
+++ b/src/main/java/entities/items/Item.java
@@ -35,6 +35,7 @@ public class Item extends Entity {
 
 
     // METHODS
+
     /**
      * Create a new item with the given position.
      */
@@ -145,5 +146,4 @@ public class Item extends Entity {
             g2.drawRect(xPixels, yPixels, tileSize, tileSize);
         }
     }
-
 }

--- a/src/main/java/entities/items/Item.java
+++ b/src/main/java/entities/items/Item.java
@@ -1,12 +1,15 @@
 package entities.items;
 
+import entities.default_game.Entity;
+import entities.default_game.IDrawOutputBoundary;
+
 import java.awt.*;
 import java.awt.image.BufferedImage;
 
 /**
  * Parent class which all items inherit from
  */
-public class Item {
+public class Item extends Entity {
 
     // VARIABLES
     /**
@@ -124,6 +127,23 @@ public class Item {
         int playerX = request.getPlayerX();
         int playerY = request.getPlayerY();
         return itemExists(playerX, playerY);
+    }
+
+    /**
+     * Draw the item.
+     */
+    public void draw(IDrawOutputBoundary d) {
+        Graphics2D g2 = d.graphics();
+        int tileSize = d.getTileSize();
+        int xPixels = getX() * tileSize;
+        int yPixels = getY() * tileSize;
+        if (image != null) {
+            g2.drawImage(image, xPixels, yPixels, tileSize, tileSize, null);
+        } else {
+            // default rectangle in case Image loading fails
+            g2.setColor(Color.BLUE);
+            g2.drawRect(xPixels, yPixels, tileSize, tileSize);
+        }
     }
 
 }

--- a/src/main/java/use_cases/default_game/CustomAssetSetter.java
+++ b/src/main/java/use_cases/default_game/CustomAssetSetter.java
@@ -1,5 +1,6 @@
 package use_cases.default_game;
 
+import entities.hazards.ChasingEnemy;
 import entities.hazards.Obstacle;
 import entities.hazards.StationaryEnemy;
 import entities.items.ItemBlackhole;
@@ -84,20 +85,32 @@ public class CustomAssetSetter {
         while (col < MAX_PANEL_COL && row < MAX_PANEL_ROW) {
             int assetNum = mazeAssetNum[col][row];  // go through each element in matrix
             switch (assetNum) {
+                case 0:
+                    // empty tile
+                    break;
                 case 1:
+                    // player?
+                case 2:
                     mazeHazards.addObstacle(new Obstacle(row, col));
                     break;
-                case 2:
+                case 3:
                     mazeHazards.addEnemy(new StationaryEnemy(row, col));
                     break;
-                case 3:
+                case 4:
+                    mazeHazards.addEnemy(new ChasingEnemy(row, col));
+                case 5:
+                    // blank
+                case 6:
+                    // blank
+                case 7:
                     mazeItems.add(new ItemKey(row, col));
                     break;
-                case 4:
+                case 8:
                     mazeItems.add(new ItemPhotons(row, col));
                     break;
-                case 5:
+                case 9:
                     mazeItems.add(new ItemBlackhole(row, col));
+                    break;
             }
             col++;
             if (col == MAX_PANEL_COL) {

--- a/src/main/java/use_cases/items/MazeItems.java
+++ b/src/main/java/use_cases/items/MazeItems.java
@@ -1,5 +1,6 @@
 package use_cases.items;
 
+import entities.default_game.IDrawOutputBoundary;
 import entities.items.ICollisionRequestModel;
 import entities.items.Item;
 
@@ -59,5 +60,14 @@ public class MazeItems {
         Item item = get(x, y);
         if (item != null)
             items.remove(item);
+    }
+
+    /**
+     * Draw all items in the maze.
+     */
+    public void draw(IDrawOutputBoundary d) {
+        for (Item item: items) {
+            item.draw(d);
+        }
     }
 }

--- a/src/test/java/items/ItemTest.java
+++ b/src/test/java/items/ItemTest.java
@@ -1,11 +1,13 @@
 package items;
 
+import entities.default_game.IDrawOutputBoundary;
 import entities.items.ICollisionRequestModel;
 import entities.items.Item;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.imageio.ImageIO;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 
@@ -78,5 +80,17 @@ public class ItemTest {
         BufferedImage image = ImageIO.read(getClass().getClassLoader().getResourceAsStream("stars.png"));
         item.setImage(image);
         Assertions.assertNotNull(item.getImage());
+    }
+
+    /**
+     * Test draw
+     */
+    @Test
+    public void DrawItem() {
+        Item item = new Item(100, 200);
+        IDrawOutputBoundary draw48 = new TestDrawRequestModel();
+        Assertions.assertEquals(48, draw48.getTileSize());
+        item.draw(draw48);
+        Assertions.assertEquals(Color.WHITE , draw48.graphics().getColor());
     }
 }

--- a/src/test/java/items/ItemTest.java
+++ b/src/test/java/items/ItemTest.java
@@ -91,6 +91,6 @@ public class ItemTest {
         IDrawOutputBoundary draw48 = new TestDrawRequestModel();
         Assertions.assertEquals(48, draw48.getTileSize());
         item.draw(draw48);
-        Assertions.assertEquals(Color.WHITE , draw48.graphics().getColor());
+        Assertions.assertEquals(Color.WHITE, draw48.graphics().getColor());
     }
 }

--- a/src/test/java/items/TestDrawRequestModel.java
+++ b/src/test/java/items/TestDrawRequestModel.java
@@ -1,0 +1,25 @@
+package items;
+
+import entities.default_game.IDrawOutputBoundary;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+
+/**
+ * an IDrawRequestModel implementation for testing only
+ */
+public class TestDrawRequestModel implements IDrawOutputBoundary {
+    @Override
+    public int getTileSize() {
+        return 48;
+    }
+
+    @Override
+    public Graphics2D graphics() {
+        BufferedImage image = new BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB);
+        return image.createGraphics();
+    }
+}
+
+


### PR DESCRIPTION
Added Draw method for Item & MazeItems

Updated CustomAssetSetter switch to cover all Assets we have so far.
- Do we want to set Player as well using AssetSetter? (case 1)
- We have 2 slots left in case we want more Item/Hazards (cases 5, 6)