### PR TITLE
Fix custom game NullPointerException

### DIFF
--- a/src/main/java/frameworks_and_drivers/default_game/GlobalFrame.java
+++ b/src/main/java/frameworks_and_drivers/default_game/GlobalFrame.java
@@ -60,7 +60,10 @@ public class GlobalFrame implements IGlobalFrameOutputBoundary {
     public void changePanelTo(String nextPanel) {
         currPanel.delete();
 
-        window.add(panelManager.getNextPanel(nextPanel, currPanel));
+        JPanel panel = panelManager.getNextPanel(nextPanel, currPanel);
+        if (panel != null) {
+            window.add(panel);
+        }
 
         window.pack();
 


### PR DESCRIPTION
The global frame is still open while editing custom mazes but that's not a very big issue